### PR TITLE
Flutter 3.29 compatibility. Unused, deprecated import removed.

### DIFF
--- a/android/src/main/java/com/softmaestri/notification/channel/flutter_notification_channel/FlutterNotificationChannelPlugin.java
+++ b/android/src/main/java/com/softmaestri/notification/channel/flutter_notification_channel/FlutterNotificationChannelPlugin.java
@@ -18,7 +18,6 @@ import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
-import io.flutter.plugin.common.PluginRegistry.Registrar;
 
 /** FlutterNotificationChannelPlugin */
 public class FlutterNotificationChannelPlugin


### PR DESCRIPTION
Only removed this line.
`import io.flutter.plugin.common.PluginRegistry.Registrar;`

It was not used by the code, just left in the import list.
**Registrar** is removed from Flutter 3.29.


This fixed this issue:
https://github.com/caseyryan/flutter_notification_channel/issues/9